### PR TITLE
Skip words with repeated flag while calculating offsets.

### DIFF
--- a/tsearch_extras.c
+++ b/tsearch_extras.c
@@ -101,7 +101,7 @@ ts_match_locs_next_match(TsMatchesData *mdata, TsMatchLocation *match)
 		int offset = mdata->char_offset;
 
 		mdata->cur_word++;
-		if (! word->skip)
+		if (! word->skip && ! word->repeated)
 		{
 			mdata->char_offset += word->len;
 


### PR DESCRIPTION
This should fix the new bug.